### PR TITLE
fix: static-page menu items all resolve to the same (alphabetically-first) page

### DIFF
--- a/src/Classes/Page.php
+++ b/src/Classes/Page.php
@@ -31,7 +31,7 @@ class Page extends \Igniter\Main\Template\Page
         $pages = PageModel::loadPages();
 
         if ($item->type == 'static-page') {
-            $pages->where('page_id', $item->reference);
+            $pages = $pages->where('page_id', $item->reference);
         }
 
         if ($pages->isEmpty()) {

--- a/src/Extension.php
+++ b/src/Extension.php
@@ -23,7 +23,7 @@ use Override;
 class Extension extends BaseExtension
 {
     protected array $morphMap = [
-        'pages' => \Igniter\Pages\Models\Page::class,
+        'pages' => Page::class,
         'static_menus' => Menu::class,
         'static_menu_items' => MenuItem::class,
     ];
@@ -82,7 +82,7 @@ class Extension extends BaseExtension
             }
         });
 
-        Relation::morphMap(['pages' => \Igniter\Pages\Models\Page::class]);
+        Relation::morphMap(['pages' => Page::class]);
 
         $this->defineRoutes();
     }

--- a/tests/Classes/PageTest.php
+++ b/tests/Classes/PageTest.php
@@ -18,16 +18,35 @@ it('returns menu type info with static page references', function(): void {
 
 it('resolves static page menu item with valid reference', function(): void {
     $theme = new Theme('tests-theme-path', ['code' => 'tests-theme']);
-    $item = (object)['type' => 'static-page', 'reference' => 1];
     $url = 'http://localhost/test-page';
     $language = Language::factory()->create(['status' => 1]);
-    PageModel::create(['permalink_slug' => 'test-page', 'title' => 'AATest Page', 'status' => 1, 'content' => '', 'language_id' => $language->getKey()]);
+    $page = PageModel::create(['permalink_slug' => 'test-page', 'title' => 'AATest Page', 'status' => 1, 'content' => '', 'language_id' => $language->getKey()]);
+    $item = (object)['type' => 'static-page', 'reference' => $page->getKey()];
+
+    PageModel::$pagesCache = null;
 
     $result = Page::resolveMenuItem($item, $url, $theme);
 
     expect($result)->toBeArray()
         ->and($result['url'])->toEndWith('/test-page')
         ->and($result['isActive'])->toBeTrue();
+});
+
+it('resolves static page menu item to the page matching its reference id', function(): void {
+    $theme = new Theme('tests-theme-path', ['code' => 'tests-theme']);
+    $language = Language::factory()->create(['status' => 1]);
+
+    PageModel::create(['permalink_slug' => 'aaa', 'title' => 'AAA Page', 'status' => 1, 'content' => '', 'language_id' => $language->getKey()]);
+    $target = PageModel::create(['permalink_slug' => 'zzz', 'title' => 'ZZZ Page', 'status' => 1, 'content' => '', 'language_id' => $language->getKey()]);
+
+    PageModel::$pagesCache = null;
+
+    $item = (object)['type' => 'static-page', 'reference' => $target->getKey()];
+    $result = Page::resolveMenuItem($item, 'http://localhost/zzz', $theme);
+
+    expect($result)->toBeArray()
+        ->and($result['url'])->toEndWith('/zzz')
+        ->and($result['url'])->not->toEndWith('/aaa');
 });
 
 it('returns null for static page menu item with invalid reference', function(): void {


### PR DESCRIPTION
## Summary

When a menu has more than one static-page item, every link points to the same page — whichever page comes first alphabetically by title. Clicking "Privacy Policy" takes you to "About Us"; clicking "Terms" also takes you to "About Us"; and so on.

## How to reproduce

1. Publish two static pages, e.g. `About Us` and `Privacy Policy`.
2. Add both as items in any menu (the seeded `footer-menu` in `tastyigniter/ti-theme-orange` already does this).
3. Click each link in the rendered menu — both go to `/about-us`.

It's been silent until now because most installs only have one static page, so "alphabetically first" is also "the right page."

## What's wrong

`Page::resolveMenuItem()` filters the cached pages by id but throws the filtered result away (it calls `$pages->where(...)` without assigning the return value back). Then `$pages->first()` runs on the unfiltered collection and picks the first one alphabetically.

## The fix

Assign the filter back: `$pages = $pages->where('page_id', $item->reference);`

One character. No behaviour change for the other menu-item types.

## Tests

The existing test for this resolver passed for the wrong reason — it hardcoded `reference => 1` and named its fixture `AATest Page` so it sorted first alphabetically, which the broken code happened to return. Updated it to reference the page it actually creates, and added a regression test that resolves a page that isn't first alphabetically. The new test fails on the bug and passes with the fix; full PageTest + MenuManagerTest suites green.
