### PR TITLE
Release v4.0.14

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -6,7 +6,7 @@ jobs:
   php-tests:
     strategy:
       matrix:
-        php: [ '8.3', '8.4' ]
+        php: [ '8.3', '8.4', '8.5' ]
     uses: tastyigniter/workflows/.github/workflows/php-tests.yml@main
     with:
       php-version: ${{ matrix.php }}

--- a/src/Extension.php
+++ b/src/Extension.php
@@ -20,6 +20,7 @@ use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Route;
 use Override;
 use Stevebauman\Purify\Facades\Purify;
+use Stevebauman\Purify\PurifyServiceProvider;
 
 class Extension extends BaseExtension
 {
@@ -38,6 +39,8 @@ class Extension extends BaseExtension
     public function register(): void
     {
         parent::register();
+
+        $this->app->register(PurifyServiceProvider::class);
 
         $this->app->singleton(MenuManager::class);
         $this->app->singleton(PageManager::class);


### PR DESCRIPTION
This release includes a minor internal refactor to service provider registration and an expansion of the CI test matrix.

## Changed

- The `PurifyServiceProvider` is now explicitly registered within `Extension` rather than relying on implicit resolution